### PR TITLE
'follow' option to support shallow scans

### DIFF
--- a/lib/gitrob/cli.rb
+++ b/lib/gitrob/cli.rb
@@ -79,6 +79,11 @@ module Gitrob
            :type    => :boolean,
            :default => true,
            :desc    => "Verify or don't verify SSL connection (careful here)"
+    option :follow,
+           :type    => :boolean,
+           :default => true,
+           :desc    => "Expand search to include repositories of org. members"
+       
     def analyze(targets)
       accept_tos
       Gitrob::CLI::Commands::Analyze.start(targets, options)

--- a/lib/gitrob/cli/commands/analyze/gathering.rb
+++ b/lib/gitrob/cli/commands/analyze/gathering.rb
@@ -29,7 +29,7 @@ module Gitrob
           def github_data_manager
             unless @github_data_manager
               @github_data_manager = Gitrob::Github::DataManager.new(
-                @targets, github_client_manager
+                @targets, github_client_manager, @options[:follow]
               )
             end
             @github_data_manager

--- a/lib/gitrob/github/data_manager.rb
+++ b/lib/gitrob/github/data_manager.rb
@@ -6,7 +6,7 @@ module Gitrob
                   :owners,
                   :repositories
 
-      def initialize(logins, client_manager)
+      def initialize(logins, client_manager, follow = true)
         @logins                  = logins
         @client_manager          = client_manager
         @unknown_logins          = []
@@ -14,6 +14,7 @@ module Gitrob
         @repositories            = []
         @repositories_for_owners = {}
         @mutex                   = Mutex.new
+        @follow                  = follow
       end
 
       def gather_owners(thread_pool)
@@ -22,6 +23,7 @@ module Gitrob
           @owners << owner
           @repositories_for_owners[owner["login"]] = []
           next unless owner["type"] == "Organization"
+          next unless @follow
           get_members(owner, thread_pool) if owner["type"] == "Organization"
         end
         @owners = @owners.uniq { |o| o["login"] }


### PR DESCRIPTION
Default behaviour of scanning org. member repos in other repositories may not be appropriate.

Use --no-follow to disable this behaviour.
