### PR TITLE
'forks' option to allow scanning of forked repos

### DIFF
--- a/lib/gitrob/cli.rb
+++ b/lib/gitrob/cli.rb
@@ -83,6 +83,10 @@ module Gitrob
            :type    => :boolean,
            :default => true,
            :desc    => "Expand search to include repositories of org. members"
+    option :forks,
+           :type    => :boolean,
+           :default => false,
+           :desc    => "Include forked repositories in scan"
        
     def analyze(targets)
       accept_tos

--- a/lib/gitrob/cli/commands/analyze/gathering.rb
+++ b/lib/gitrob/cli/commands/analyze/gathering.rb
@@ -29,7 +29,7 @@ module Gitrob
           def github_data_manager
             unless @github_data_manager
               @github_data_manager = Gitrob::Github::DataManager.new(
-                @targets, github_client_manager, @options[:follow]
+                @targets, github_client_manager, @options[:follow], @options[:forks]
               )
             end
             @github_data_manager


### PR DESCRIPTION
Enables scanning of forks. Forks may contain sensitive data.

Use the --forks option to enable.
